### PR TITLE
Add high-level AGENTS guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Plan9port Agent Instructions
+
+## Purpose
+This repository contains Plan 9 from Bell Labs software ported to Unix. It provides a collection of command-line tools, libraries, fonts and other data needed to reproduce a Plan 9 development environment on Unix systems.
+
+These instructions help future agents or developers explore and modify the code base.
+
+## Getting Started
+1. Read `README.md` for a short introduction.
+2. Run `./INSTALL` to build and install the system. The script builds the `mk` tool first and then uses it to compile the rest of the tree.
+3. After installation, the environment is rooted under the `PLAN9` directory (default `/usr/local/plan9`). Executables live in `\$PLAN9/bin`.
+
+## Repository Layout
+- `src/` – C source code for libraries and commands. See `src/AGENTS.md` for details.
+- `bin/` – Shell scripts and command wrappers. See `bin/AGENTS.md`.
+- `lib/` – Configuration files, resources and data used by programs. See `lib/AGENTS.md`.
+- `font/`, `face/`, `mac/` – Fonts and bitmap resources.
+- `man/` – Manual pages.
+- `ndb/` – Example network database entries.
+- `news/` – Historical news posts and update notes.
+
+Additional directories (`dict/`, `unix/`, `proto/`, `sky/`, `tmac/`, `postscript/`, etc.) provide supporting data and utilities.
+
+## Build Notes
+- The build system uses the Plan 9 `mk` tool rather than standard Make. Most directories contain a `mkfile` that describes the build rules.
+- Running `mk install` inside a directory typically builds and installs that component.
+- The root `Makefile` is only a placeholder; do not rely on it for building.
+
+## Guiding Principles
+- Preserve portability across Unix-like systems.
+- Keep the directory structure aligned with the original Plan 9 tree when possible.
+- Use plain C and sh; avoid introducing dependencies without strong justification.
+
+## Further Documentation
+Check the `man/` directory for manual pages describing individual tools and libraries. Each program usually has an accompanying manual page accessible with the `man` command after installation.
+

--- a/bin/AGENTS.md
+++ b/bin/AGENTS.md
@@ -1,0 +1,16 @@
+# Binary Scripts Guide
+
+## Overview
+The `bin` directory contains shell scripts and wrappers that emulate Plan 9 command behavior on Unix.
+Many scripts prefix Plan 9 programs with `9` to avoid clashes with native Unix tools.
+
+Example scripts include `9c` (Plan 9 C compiler front end) and `9l` (Plan 9 linker wrapper).
+
+## Usage Notes
+- Scripts expect `PLAN9` environment variable pointing to the installed tree.
+- Most scripts simply invoke the corresponding program in `\$PLAN9/bin` after adjusting the environment or arguments.
+
+## Development Tips
+- Keep scripts POSIX sh compatible.
+- Maintain consistency with upstream Plan 9 command interfaces.
+

--- a/lib/AGENTS.md
+++ b/lib/AGENTS.md
@@ -1,0 +1,17 @@
+# Library Resources Guide
+
+## Overview
+The `lib` directory houses configuration files and auxiliary resources used by the Plan 9 tools.
+Examples include fonts, grammar files for `grap`, and subdirectories containing language dictionaries.
+
+Some notable components:
+- `git/` holds scripts for interacting with Git.
+- `fortunes` provides quotes used by the `fortune` program.
+
+## Usage Notes
+- Files in this directory are installed under `\$PLAN9/lib`.
+- Scripts and programs rely on these resources being present at runtime.
+
+## Editing Guidance
+Keep changes minimal and preserve compatibility with Plan 9 programs expecting these files. Document any additions in README files within the subdirectories.
+

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,19 @@
+# Source Tree Guide
+
+## Overview
+The `src` directory holds the core source code for Plan 9 from Bell Labs. It is organized into libraries and commands.
+
+- `cmd/` contains hundreds of subdirectories, each implementing a command-line utility or graphical program from Plan 9.
+- `lib*` directories implement libraries used by the commands and by external projects.
+- `mkfile` at the top level orchestrates building all libraries and commands using the Plan 9 `mk` tool.
+
+## Building
+1. Run `mk install` in this directory after the top level `./INSTALL` script has built `mk`.
+2. Each subdirectory generally contains its own `mkfile` defining build rules.
+3. Libraries install headers under `include/` and static archives in `\$PLAN9/lib`.
+
+## Notes for Future Agents
+- Many commands are self-contained C programs. Explore `cmd/<tool>/` to understand individual utilities.
+- Libraries follow the naming convention `lib*`. For example, `lib9` provides the standard Plan 9 C library replacements for Unix.
+- Avoid modifying original Plan 9 code without preserving portability.
+


### PR DESCRIPTION
## Summary
- add root AGENTS instructions for the repo layout
- add AGENTS for core directories (`src`, `bin`, `lib`)

## Testing
- `git status --short`