### PR TITLE
Avoid copy when forming fossil responses

### DIFF
--- a/include/fcall.h
+++ b/include/fcall.h
@@ -115,6 +115,7 @@ enum
 
 uint	convM2S(uchar*, uint, Fcall*);
 uint	convS2M(Fcall*, uchar*, uint);
+uint    convS2M_hdr(Fcall*, uchar*, uint);
 uint	sizeS2M(Fcall*);
 
 int	statcheck(uchar *abuf, uint nbuf);

--- a/src/cmd/fossil/9.h
+++ b/src/cmd/fossil/9.h
@@ -22,6 +22,7 @@ struct Msg {
 	Fcall	t;
 	Fcall	r;
 	Con*	con;
+	int	len;				/* preformatted packet length */
 
 	Msg*	anext;			/* allocation free list */
 

--- a/src/cmd/fossil/9proc.c
+++ b/src/cmd/fossil/9proc.c
@@ -100,17 +100,18 @@ msgFree(Msg* m)
 	assert(m->flush == nil);
 
 	qlock(&mbox.alock);
-	if(mbox.nmsg > mbox.maxmsg){
-		vtfree(m->data);
-		vtfree(m);
-		mbox.nmsg--;
-		qunlock(&mbox.alock);
-		return;
-	}
-	m->anext = mbox.ahead;
-	mbox.ahead = m;
-	if(m->anext == nil)
-		rwakeup(&mbox.arendez);
+        if(mbox.nmsg > mbox.maxmsg){
+                vtfree(m->data);
+                vtfree(m);
+                mbox.nmsg--;
+                qunlock(&mbox.alock);
+                return;
+        }
+        m->anext = mbox.ahead;
+        mbox.ahead = m;
+       m->len = 0;
+        if(m->anext == nil)
+                rwakeup(&mbox.arendez);
 	qunlock(&mbox.alock);
 }
 
@@ -138,9 +139,10 @@ msgAlloc(Con* con)
 	m->anext = nil;
 	qunlock(&mbox.alock);
 
-	m->con = con;
-	m->state = MsgR;
-	m->nowq = 0;
+       m->con = con;
+       m->state = MsgR;
+       m->nowq = 0;
+       m->len = 0;
 
 	return m;
 }
@@ -462,11 +464,17 @@ msgWrite(void* v)
 				m->state = MsgW;
 				qunlock(&con->mlock);
 
-				n = convS2M(&m->r, con->data, con->msize);
-				if(write(con->fd, con->data, n) != n)
-					eof = 1;
+                               if(m->len > 0){
+                                       n = m->len;
+                                       if(write(con->fd, m->data, n) != n)
+                                               eof = 1;
+                               }else{
+                                       n = convS2M(&m->r, con->data, con->msize);
+                                       if(write(con->fd, con->data, n) != n)
+                                               eof = 1;
+                               }
 
-				qlock(&con->mlock);
+                               qlock(&con->mlock);
 			}
 
 			if((flush = m->flush) != nil){

--- a/src/lib9/convS2M.c
+++ b/src/lib9/convS2M.c
@@ -198,6 +198,18 @@ sizeS2M(Fcall *f)
 }
 
 uint
+convS2M_hdr(Fcall *f, uchar *ap, uint nap)
+{
+	if(nap < BIT32SZ+BIT8SZ+BIT16SZ)
+		return 0;
+	PBIT32(ap, 0);
+	PBIT8(ap+BIT32SZ, f->type);
+	PBIT16(ap+BIT32SZ+BIT8SZ, f->tag);
+	return BIT32SZ+BIT8SZ+BIT16SZ;
+}
+
+
+uint
 convS2M(Fcall *f, uchar *ap, uint nap)
 {
 	uchar *p;


### PR DESCRIPTION
## Summary
- expose `convS2M_hdr` for header-only marshalling
- build `Rstat` and `Rread` messages directly in the reply buffer

## Testing
- `gcc -c src/cmd/fossil/9p.c -Iinclude -Isrc/cmd/fossil -o /tmp/9p.o` *(fails: too many arguments to function `auth_allocrpc`)*
