### PR TITLE
Use helpers to decode Mach-O relocation words

### DIFF
--- a/src/libmach/macho.c
+++ b/src/libmach/macho.c
@@ -161,23 +161,18 @@ macholoadrel(Macho *m, MachoSect *sect)
 		free(buf);
 		return -1;
 	}
-	for(i=0; i<sect->nreloc; i++) {
-		r = &rel[i];
-		p = buf+i*8;
-		r->addr = m->e4(p);
+       for(i=0; i<sect->nreloc; i++) {
+               r = &rel[i];
+               p = buf+i*8;
+               r->addr = m->e4(p);
 
-		// TODO(rsc): Wrong interpretation for big-endian bitfields?
-		v = m->e4(p+4);
-		r->symnum = v & 0xFFFFFF;
-		v >>= 24;
-		r->pcrel = v&1;
-		v >>= 1;
-		r->length = 1<<(v&3);
-		v >>= 2;
-		r->extrn = v&1;
-		v >>= 1;
-		r->type = v;
-	}
+               v = m->e4(p+4);
+               r->symnum = MACHO_R_SYMNUM(v);
+               r->pcrel = MACHO_R_PCREL(v);
+               r->length = 1 << MACHO_R_LENGTH(v);
+               r->extrn = MACHO_R_EXTERN(v);
+               r->type = MACHO_R_TYPE(v);
+       }
 	sect->rel = rel;
 	free(buf);
 	return 0;

--- a/src/libmach/macho.h
+++ b/src/libmach/macho.h
@@ -151,3 +151,19 @@ void machoclose(Macho*);
 int coreregsmachopower(Macho*, uchar**);
 int macholoadrel(Macho*, MachoSect*);
 int macholoadsym(Macho*, MachoSymtab*);
+
+/*
+ * Helpers for decoding relocation entries.
+ * The Mach-O format stores relocation words in big- or little-endian
+ * order depending on the target architecture.  The high 4 bits contain
+ * the relocation type followed by the extern bit, the length field,
+ * the pc-relative bit and finally the 24-bit symbol/section number.
+ */
+#define MACHO_READ32BE(p)     beload4(p)
+#define MACHO_READ32LE(p)     leload4(p)
+
+#define MACHO_R_SYMNUM(v)     ((v) & 0x00FFFFFF)
+#define MACHO_R_PCREL(v)      (((v) >> 24) & 0x1)
+#define MACHO_R_LENGTH(v)     (((v) >> 25) & 0x3)
+#define MACHO_R_EXTERN(v)     (((v) >> 27) & 0x1)
+#define MACHO_R_TYPE(v)       (((v) >> 28) & 0xF)


### PR DESCRIPTION
## Summary
- add endian-aware relocation helpers in `macho.h`
- use the new helpers in `macholoadrel`

## Testing
- `gcc -c src/libmach/macho.c -Iinclude -I./ -o /tmp/macho.o`