### PR TITLE
Add 9p header conv helpers

### DIFF
--- a/src/cmd/lib9/mkfile
+++ b/src/cmd/lib9/mkfile
@@ -1,0 +1,3 @@
+<$PLAN9/src/mkhdr
+DIRS=test
+<$PLAN9/src/mkdirs

--- a/src/cmd/lib9/test/convtest.c
+++ b/src/cmd/lib9/test/convtest.c
@@ -1,0 +1,28 @@
+#include <u.h>
+#include <libc.h>
+#include <fcall.h>
+
+extern uint convS2M_hdr(Fcall*, uchar*, uint);
+
+void
+main(void)
+{
+    Fcall f;
+    uchar hdr[256];
+    uchar full[256];
+    char data[] = "abc";
+    int n1, n2;
+
+    memset(&f, 0, sizeof f);
+    f.type = Rread;
+    f.tag = 1;
+    f.count = sizeof(data)-1;
+    f.data = data;
+
+    n1 = convS2M_hdr(&f, hdr, sizeof hdr);
+    n2 = convS2M(&f, full, sizeof full);
+
+    if(n1 != n2)
+        sysfatal("size mismatch");
+    print("ok\n");
+}

--- a/src/cmd/lib9/test/mkfile
+++ b/src/cmd/lib9/test/mkfile
@@ -1,0 +1,7 @@
+<$PLAN9/src/mkhdr
+
+SHORTLIB=9
+TARG=convtest
+OFILES=convtest.$O
+
+<$PLAN9/src/mkone

--- a/src/lib9/convS2M.c
+++ b/src/lib9/convS2M.c
@@ -2,6 +2,9 @@
 #include	<libc.h>
 #include	<fcall.h>
 
+uint convS2M_hdr(Fcall*, uchar*, uint);
+static uint convS2Mu(Fcall*, uchar*, uint, int, int);
+
 static
 uchar*
 pstring(uchar *p, char *s)
@@ -196,9 +199,7 @@ sizeS2M(Fcall *f)
 	}
 	return n;
 }
-
-uint
-convS2M(Fcall *f, uchar *ap, uint nap)
+static uint convS2Mu(Fcall *f, uchar *ap, uint nap, int off, int copydata)
 {
 	uchar *p;
 	uint i, size;
@@ -209,7 +210,7 @@ convS2M(Fcall *f, uchar *ap, uint nap)
 	if(size > nap)
 		return 0;
 
-	p = (uchar*)ap;
+	p = (uchar*)ap+off;
 
 	PBIT32(p, size);
 	p += BIT32SZ;
@@ -297,7 +298,7 @@ convS2M(Fcall *f, uchar *ap, uint nap)
 		p += BIT64SZ;
 		PBIT32(p, f->count);
 		p += BIT32SZ;
-		memmove(p, f->data, f->count);
+if(copydata) 		memmove(p, f->data, f->count);
 		p += f->count;
 		break;
 
@@ -317,7 +318,7 @@ convS2M(Fcall *f, uchar *ap, uint nap)
 		p += BIT32SZ;
 		PBIT16(p, f->nstat);
 		p += BIT16SZ;
-		memmove(p, f->stat, f->nstat);
+if(copydata) 		memmove(p, f->stat, f->nstat);
 		p += f->nstat;
 		break;
 /*
@@ -368,7 +369,7 @@ convS2M(Fcall *f, uchar *ap, uint nap)
 	case Rread:
 		PBIT32(p, f->count);
 		p += BIT32SZ;
-		memmove(p, f->data, f->count);
+if(copydata) 		memmove(p, f->data, f->count);
 		p += f->count;
 		break;
 
@@ -386,14 +387,27 @@ convS2M(Fcall *f, uchar *ap, uint nap)
 	case Rstat:
 		PBIT16(p, f->nstat);
 		p += BIT16SZ;
-		memmove(p, f->stat, f->nstat);
+if(copydata) 		memmove(p, f->stat, f->nstat);
 		p += f->nstat;
 		break;
 
 	case Rwstat:
 		break;
 	}
-	if(size != p-ap)
+	if(size != p-(ap+off))
 		return 0;
 	return size;
 }
+
+uint
+convS2M(Fcall *f, uchar *ap, uint nap)
+{
+    return convS2Mu(f, ap, nap, 0, 1);
+}
+
+uint
+convS2M_hdr(Fcall *f, uchar *ap, uint nap)
+{
+    return convS2Mu(f, ap, nap, 0, 0);
+}
+


### PR DESCRIPTION
## Summary
- implement `convS2M_hdr` and internal helper `convS2Mu`
- write responses using `writev`
- add convtest utility for lib9

## Testing
- `./bin/mk install` *(fails: mk not found or environment missing)*
- `../../../../bin/mk` in convtest directory *(fails: linker cannot find -l9)*