### PR TITLE
Fix UpasFS mount handling

### DIFF
--- a/src/cmd/acme/mail/readme
+++ b/src/cmd/acme/mail/readme
@@ -55,3 +55,6 @@ exists, Acme Mail will save your a copy of your outgoing messages
 there.  Attachments are described in the copy but not included.
 
 The -m mntpoint flag specifies a different mount point for /upas/fs.
+The -s flag causes upas/fs to post a service named /srv/upasfs.$user
+instead of mounting it.  Without -s, upas/fs mounts the file system
+at the chosen mount point.

--- a/src/cmd/upas/fs/fs.c
+++ b/src/cmd/upas/fs/fs.c
@@ -247,15 +247,13 @@ threadmain(int argc, char *argv[])
 		break;
 	default:
 		close(p[0]);	/* don't deadlock if child fails */
-		if(srvpost){
-			sprint(srvfile, "/srv/upasfs.%s", user);
-			/* post(srvfile, "upasfs", p[1]);  jpc */
-			post9pservice(p[1], "upasfs", nil);   /* jpc */
-		} else {
-			error("tried to mount, fixme");     /* jpc */
-			/* if(mount(p[1], -1, mntpt, MREPL, "") < 0)
-				error("mount failed");   jpc */
-		}
+               if(srvpost){
+                       sprint(srvfile, "/srv/upasfs.%s", user);
+                       post9pservice(p[1], "upasfs", nil);
+               } else {
+                       if(post9pservice(p[1], nil, mntpt) < 0)
+                               error("mount failed");
+               }
 	}
 	threadexits(0);
 }


### PR DESCRIPTION
## Summary
- hook up mounting path in `upas/fs`
- document the `-s` flag for upas/fs usage

## Testing
- `git status --short`
