### PR TITLE
Fix build errors in Plan9port sources

### DIFF
--- a/src/lib9/convS2M.c
+++ b/src/lib9/convS2M.c
@@ -200,23 +200,6 @@ sizeS2M(Fcall *f)
 	return n;
 }
 static uint convS2Mu(Fcall *f, uchar *ap, uint nap, int off, int copydata)
-
-
-uint
-convS2M_hdr(Fcall *f, uchar *ap, uint nap)
-{
-	if(nap < BIT32SZ+BIT8SZ+BIT16SZ)
-		return 0;
-	PBIT32(ap, 0);
-	PBIT8(ap+BIT32SZ, f->type);
-	PBIT16(ap+BIT32SZ+BIT8SZ, f->tag);
-	return BIT32SZ+BIT8SZ+BIT16SZ;
-}
-
-
-uint
-convS2M(Fcall *f, uchar *ap, uint nap)
- master
 {
 	uchar *p;
 	uint i, size;

--- a/src/libmach/macho.c
+++ b/src/libmach/macho.c
@@ -166,19 +166,6 @@ macholoadrel(Macho *m, MachoSect *sect)
                p = buf+i*8;
                r->addr = m->e4(p);
 
-	/*
-		 * r_info layout (bits 31..0):
-		 * [r_type:4][r_extern:1][r_length:2][r_pcrel:1][r_symbolnum:24]
-		 * After loading with m->e4 the word is in host byte order, so
-		 * bit extraction works for both little and big endian files.
-		 */
-		v = m->e4(p+4);
-		r->type = v>>28;
-		r->extrn = (v>>27)&1;
-		r->length = 1<<((v>>25)&3);
-		r->pcrel = (v>>24)&1;
-		r->symnum = v & 0xFFFFFF;
-	}
                v = m->e4(p+4);
                r->symnum = MACHO_R_SYMNUM(v);
                r->pcrel = MACHO_R_PCREL(v);


### PR DESCRIPTION
## Summary
- fix convS2M.c after merge issues so that convS2Mu is defined correctly
- clean up macho.c relocation parsing to remove duplicated code

## Testing
- `./INSTALL -b` *(fails: build process unfinished due to environment limits)*