### PR TITLE
Add preliminary Meson build setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,15 @@ This is a port of many Plan 9 libraries and programs to Unix.
 Installation
 ------------
 
-To install, run ./INSTALL.  It builds mk and then uses mk to
-run the rest of the installation.
+To install using the traditional Plan 9 build system, run `./INSTALL`.
+This builds `mk` and then uses it to compile everything else.
+
+Alternatively, a minimal Meson build is provided for modern toolchains
+using `clang` and the C23 standard. Configure it with:
+
+```sh
+meson setup build && ninja -C build
+```
 
 For more details, see install(1), at install.txt in this directory
 and at https://9fans.github.io/plan9port/man/man1/install.html.

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,8 @@
+project('plan9port', 'c', default_options: ['c_std=c23'])
+cc = meson.get_compiler('c')
+if cc.get_id() != 'clang'
+  warning('This project expects clang for best compatibility')
+endif
+add_project_arguments('-Iinclude', language: 'c')
+subdir('src/lib9')
+subdir('src/cmd')

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,12 @@ done
 
 apt-get update -y
 
+# Use clang and modern C23 standard by default
+export CC=clang
+export CXX=clang++
+export CFLAGS="-std=c23"
+export CXXFLAGS="-std=c++23"
+
 for pkg in \
   build-essential gcc g++ clang lld llvm \
   clang-format uncrustify astyle editorconfig pre-commit \

--- a/src/cmd/meson.build
+++ b/src/cmd/meson.build
@@ -1,0 +1,3 @@
+executable('cat', 'cat.c',
+    include_directories: include_directories('../../include'),
+    dependencies: [dependency('lib9')])

--- a/src/lib9/fmt/fmt.c
+++ b/src/lib9/fmt/fmt.c
@@ -21,6 +21,9 @@
 #define ATOMIC_VAR_INIT(x) (x)
 #else
 #include <stdatomic.h>
+#if __STDC_VERSION__ >= 202311L && !defined(ATOMIC_VAR_INIT)
+#define ATOMIC_VAR_INIT(value) (value)
+#endif
 #endif
 
 #include "plan9.h"

--- a/src/lib9/meson.build
+++ b/src/lib9/meson.build
@@ -1,0 +1,45 @@
+# Minimal subset of lib9 built with clang and C23
+lib9_sources = [
+    '_exits.c', '_p9dialparse.c', '_p9dir.c', 'announce.c', 'argv0.c', 'atexit.c',
+    'atnotify.c', 'atoi.c', 'atol.c', 'atoll.c', 'await.c', 'cistrcmp.c',
+    'cistrncmp.c', 'cistrstr.c', 'cleanname.c', 'convD2M.c', 'convM2D.c',
+    'convM2S.c', 'convS2M.c', 'crypt.c', 'ctime.c', 'debugmalloc.c', 'dial.c',
+    'dirfstat.c', 'dirfwstat.c', 'dirmodefmt.c', 'dirstat.c', 'dirwstat.c',
+    'dup.c', 'encodefmt.c', 'errstr.c', 'exec.c', 'execl.c', 'exitcode.c',
+    'fcallfmt.c', 'fmtlock2.c', 'frand.c', 'frexp.c', 'getcallerpc.c',
+    'getenv.c', 'getfields.c', 'getnetconn.c', 'getns.c', 'getuser.c',
+    'getwd.c', 'jmp.c', 'lnrand.c', 'lock.c', 'lrand.c', 'main.c', 'malloc.c',
+    'malloctag.c', 'mallocz.c', 'nan.c', 'needsrcquote.c', 'needstack.c',
+    'netcrypt.c', 'netmkaddr.c', 'notify.c', 'nrand.c', 'nulldir.c', 'open.c',
+    'opentemp.c', 'pin.c', 'pipe.c', 'post9p.c', 'postnote.c', 'qlock.c',
+    'quote.c', 'rand.c', 'read9pmsg.c', 'readcons.c', 'readn.c', 'rfork.c',
+    'searchpath.c', 'sendfd.c', 'sleep.c', 'strdup.c', 'strecpy.c',
+    'sysfatal.c', 'syslog.c', 'sysname.c', 'test.c', 'testfltfmt.c',
+    'testfmt.c', 'testprint.c', 'time.c', 'tm2sec.c', 'tokenize.c', 'truerand.c',
+    'u16.c', 'u32.c', 'u64.c', 'unsharp.c', 'wait.c', 'waitpid.c', 'write.c',
+    'zoneinfo.c',
+]
+lib9_fmt = files(
+    'fmt/charstod.c','fmt/dofmt.c','fmt/dorfmt.c','fmt/errfmt.c','fmt/fltfmt.c',
+    'fmt/fmt.c','fmt/fmtfd.c','fmt/fmtfdflush.c','fmt/fmtlocale.c','fmt/fmtlock.c',
+    'fmt/fmtnull.c','fmt/fmtprint.c','fmt/fmtquote.c','fmt/fmtrune.c','fmt/fmtstr.c',
+    'fmt/fmtvprint.c','fmt/fprint.c','fmt/nan64.c','fmt/pow10.c','fmt/print.c',
+    'fmt/runefmtstr.c','fmt/runeseprint.c','fmt/runesmprint.c','fmt/runesnprint.c',
+    'fmt/runesprint.c','fmt/runevseprint.c','fmt/runevsmprint.c','fmt/runevsnprint.c',
+    'fmt/seprint.c','fmt/smprint.c','fmt/snprint.c','fmt/sprint.c','fmt/strtod.c',
+    'fmt/test.c','fmt/test2.c','fmt/test3.c','fmt/vfprint.c','fmt/vseprint.c',
+    'fmt/vsmprint.c','fmt/vsnprint.c'
+)
+lib9_utf = files(
+    'utf/rune.c','utf/runestrcat.c','utf/runestrchr.c','utf/runestrcmp.c',
+    'utf/runestrcpy.c','utf/runestrdup.c','utf/runestrecpy.c','utf/runestrlen.c',
+    'utf/runestrncat.c','utf/runestrncmp.c','utf/runestrncpy.c','utf/runestrrchr.c',
+    'utf/runestrstr.c','utf/runetype.c','utf/utfecpy.c','utf/utflen.c',
+    'utf/utfnlen.c','utf/utfrrune.c','utf/utfrune.c','utf/utfutf.c'
+)
+lib9 = static_library('9', lib9_sources + lib9_fmt + lib9_utf,
+    include_directories: include_directories('.', 'fmt', 'utf', '../../include'))
+
+meson.override_dependency('lib9', declare_dependency(link_with: lib9,
+    include_directories: include_directories('.', 'fmt', 'utf', '../../include')))
+*** End File


### PR DESCRIPTION
## Summary
- provide Meson build files building lib9 and `cat`
- adjust `fmt.c` for C23's removal of `ATOMIC_VAR_INIT`
- document Meson usage in README
- prefer clang/C23 in `setup.sh`

## Testing
- `meson setup build` *(fails: `meson: command not found`)*
- `ninja -C build` *(fails: build directory missing)*