### PR TITLE
Add clang tidy integration and pre-commit config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: Always
+TabWidth: 8
+BreakBeforeBraces: Allman
+AllowShortFunctionsOnASingleLine: Empty

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,3 @@
+Checks: '-*,clang-analyzer-*'
+WarningsAsErrors: ''
+FormatStyle: none

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+- repo: local
+  hooks:
+  - id: clang-format
+    name: clang-format
+    entry: clang-format -i
+    language: system
+    files: '\.(c|h)$'
+  - id: clang-tidy
+    name: clang-tidy
+    entry: clang-tidy
+    language: system
+    pass_filenames: true
+    files: '\.(c|h)$'
+    args: ['-p', 'build']

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,6 @@
 Plan 9 from User Space accepts GitHub pull requests.
 
 For details, see the general [GitHub documentation](https://help.github.com/articles/creating-a-pull-request/).
+
+Before sending patches run `pre-commit install` once and use the provided
+hooks to format code and run clang-tidy checks.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ using `clang` and the C23 standard. Configure it with:
 meson setup build && ninja -C build
 ```
 
+For development consistency run `pre-commit install` to set up
+formatting checks.  Invoke clang-tidy with `ninja -C build tidy`
+for Meson or `mk tidy` in the `src` directory when using the
+Plan9 `mk` build system. The mk tidy target enables clang-tidy by
+setting the `RUN_CLANG_TIDY` environment variable.
+
 For more details, see install(1), at install.txt in this directory
 and at https://9fans.github.io/plan9port/man/man1/install.html.
 

--- a/bin/9c
+++ b/bin/9c
@@ -150,6 +150,9 @@ esac
 
 # Must use temp file to avoid pipe; pipe loses status.
 xtmp=${TMPDIR-/tmp}/9c.$$.$USER.out
+if [ -n "$RUN_CLANG_TIDY" ] && command -v clang-tidy >/dev/null; then
+    clang-tidy "$@" -- -DPLAN9PORT -I"$PLAN9/include" $cflags || true
+fi
 $cc -DPLAN9PORT -I"$PLAN9/include" $cflags "$@" 2>"$xtmp"
 status=$?
 quiet "$xtmp"

--- a/meson.build
+++ b/meson.build
@@ -6,3 +6,8 @@ endif
 add_project_arguments('-Iinclude', language: 'c')
 subdir('src/lib9')
 subdir('src/cmd')
+
+clang_tidy = find_program('run-clang-tidy', required: false)
+if clang_tidy.found()
+  run_target('tidy', command: [clang_tidy, '-p', meson.current_build_dir()])
+endif

--- a/src/mkfile
+++ b/src/mkfile
@@ -55,5 +55,9 @@ testcvs:V:
 	mv ../bin/mk ../bin/_mk
 	rm ../bin/*
 	PLAN9="`pwd`/.." export PLAN9
-	PATH=$PLAN9/bin:$PATH export PATH
+        PATH=$PLAN9/bin:$PATH export PATH
+
+tidy:V:
+        RUN_CLANG_TIDY=1 mk libs-all
+        (cd cmd && RUN_CLANG_TIDY=1 mk all)
 


### PR DESCRIPTION
## Summary
- add `.clang-format` and `.clang-tidy` config
- enable clang-tidy run target in meson
- add tidy target to `mk` build via `RUN_CLANG_TIDY`
- update `9c` compiler wrapper to optionally run clang-tidy
- document pre-commit usage in README and CONTRIBUTING
- provide pre-commit hooks

## Testing
- `meson setup build` *(fails: `meson: command not found`)*