### PR TITLE
Add C23 hello example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ using `clang` and the C23 standard. Configure it with:
 ```sh
 meson setup build && ninja -C build
 ```
+The sample program `c23hello` demonstrates a minimal C23 executable.
 
 For more details, see install(1), at install.txt in this directory
 and at https://9fans.github.io/plan9port/man/man1/install.html.

--- a/src/cmd/c23hello.c
+++ b/src/cmd/c23hello.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdint.h>
+
+int main(void) {
+    static_assert(sizeof(int) == 4, "int must be 4 bytes on x86");
+    puts("hello from C23");
+    return 0;
+}

--- a/src/cmd/meson.build
+++ b/src/cmd/meson.build
@@ -1,3 +1,5 @@
 executable('cat', 'cat.c',
     include_directories: include_directories('../../include'),
     dependencies: [dependency('lib9')])
+
+executable('c23hello', 'c23hello.c')


### PR DESCRIPTION
## Summary
- add a tiny C23 `c23hello` example program
- compile `c23hello` via meson build
- note sample program in README

## Testing
- `meson setup build && ninja -C build` *(fails: `meson: command not found`)*
- `./INSTALL` *(failed: build aborted before completion)*
- `clang -std=c23 src/cmd/c23hello.c -o c23hello`