### PR TITLE
Fix compile warnings in lib9 and build script

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -18,7 +18,6 @@ usegcc()
 		-Wno-stringop-truncation \
 		-Wno-stringop-overflow \
 		-Wno-format-truncation \
-		-Wno-deprecated-pragma \
 		-Wno-unused-but-set-variable \
 		-Wno-deprecated-declarations \
 		-fno-omit-frame-pointer \
@@ -80,7 +79,6 @@ useclang()
 		-Wno-gnu-designator \
 		-Wno-array-bounds \
 		-Wno-unneeded-internal-declaration \
-		-Wno-deprecated-pragma \
 		-Wno-unused-but-set-variable \
 		-fsigned-char \
 		-fno-caret-diagnostics \

--- a/include/libc.h
+++ b/include/libc.h
@@ -769,7 +769,7 @@ extern	int	notifyon(char*);
 extern	int	notifyoff(char*);
 extern	int	p9open(char*, int);
 extern	int	fd2path(int, char*, int);
-extern	int	p9pipe(int*);
+extern	int	p9pipe(int fd[2]);
 /*
  * use defs from <unistd.h>
 extern	long	pread(int, void*, long, vlong);


### PR DESCRIPTION
## Summary
- fix p9pipe prototype to avoid GCC array-bound warning
- drop unsupported `-Wno-deprecated-pragma` flag from the build wrapper

## Testing
- `gcc -Iinclude -c src/lib9/pipe.c -o /tmp/pipe.o`
- `./INSTALL` *(fails: undefined reference to `static_assert`)*