### PR TITLE
Add -a arch support to INSTALL

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,26 +2,33 @@
 
 dobuild=true
 doinstall=true
+OBJTYPE=
 
-case "x$1" in
-x)
-	;;
-x-b)
-	dobuild=true
-	doinstall=false
-	;;
-x-c)
-	dobuild=false
-	doinstall=true
-	;;
-x-r)
-	shift
-	PLAN9_TARGET=$1
-	;;
-*)
-	echo 'usage: INSTALL [-b | -c] [-r path]' 1>&2
-	exit 1
-esac
+while [ $# -gt 0 ]; do
+        case "$1" in
+        -b)
+                dobuild=true
+                doinstall=false
+                ;;
+        -c)
+                dobuild=false
+                doinstall=true
+                ;;
+        -r)
+                shift
+                PLAN9_TARGET=$1
+                ;;
+        -a)
+                shift
+                OBJTYPE=$1
+                ;;
+        *)
+                echo 'usage: INSTALL [-b | -c] [-r path] [-a arch]' 1>&2
+                exit 1
+                ;;
+        esac
+        shift
+done
 
 PLAN9=`pwd` export PLAN9
 
@@ -36,6 +43,7 @@ PLAN9=`pwd` export PLAN9
 PATH=/bin:/usr/bin:$PLAN9/bin:$PATH export PATH
 [ -z "$PLAN9_TARGET" ] && PLAN9_TARGET="$PLAN9"
 export PLAN9_TARGET
+[ -n "$OBJTYPE" ] && export OBJTYPE
 
 case `uname` in
 SunOS)
@@ -71,7 +79,7 @@ DragonFly|*BSD)
 esac
 
 (
-if [ `uname` = SunOS ]; then
+if [ `uname` = SunOS ] && [ -z "$OBJTYPE" ]; then
 	# On Solaris x86, uname -p cannot be trusted.
 	echo "* Running on Solaris: checking architecture..."
 	case "$(isainfo -n)" in
@@ -89,7 +97,7 @@ if [ `uname` = SunOS ]; then
 	esac
 fi
 
-if [ `uname` = Darwin ]; then
+if [ `uname` = Darwin ] && [ -z "$OBJTYPE" ]; then
 	export NPROC=$(sysctl hw.ncpu | sed 's/hw.ncpu: //')
 	# On Darwin, uname -m -p cannot be trusted.
 	echo "* Running on Darwin..."

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Installation
 ------------
 
 To install using the traditional Plan 9 build system, run `./INSTALL`.
-This builds `mk` and then uses it to compile everything else.
+This builds `mk` and then uses it to compile everything else. Pass
+`-a <arch>` to override the detected architecture (for example
+`amd64`, `386`, or `ia16`).
 
 Alternatively, a minimal Meson build is provided for modern toolchains
 using `clang` and the C23 standard. Configure it with:

--- a/install.txt
+++ b/install.txt
@@ -5,7 +5,7 @@
           install - notes about Plan 9 from User Space installation
 
      SYNOPSIS
-          cd /usr/local/plan9; ./INSTALL [ -b | -c ] [ -r path ]
+         cd /usr/local/plan9; ./INSTALL [ -b | -c ] [ -r path ] [ -a arch ]
 
      DESCRIPTION
           To obtain the Plan 9 tree, use Git (see git(1)) or download
@@ -35,9 +35,10 @@
           tree in a temporary work directory, but the second step must
           be done once the tree is in its final location.  If you want
           to build the project in one location and then install into
-          another location, use -r path to specify the final location
-          of Plan9 tree.  These flags are only necessary when trying
-          to conform to the expectations of certain package management
+         another location, use -r path to specify the final location
+         of Plan9 tree.  Use -a arch to override the detected
+         architecture.  These flags are only necessary when trying
+         to conform to the expectations of certain package management
           systems.
 
           At the end of the installation, INSTALL prints suggested

--- a/src/mkenv
+++ b/src/mkenv
@@ -2,22 +2,24 @@
 # and also valid shell input for ../dist/buildmk
 
 SYSNAME=`uname`
-# OBJTYPE=`(uname -m -p 2>/dev/null || uname -m) | sed '
-# 	s;.*i[3-6]86.*;386;;
-# 	s;.*i86pc.*;386;;
-# 	s;.*amd64.*;x86_64;;
-# 	s;.*x86_64.*;x86_64;;
-# 	s;.*armv.*;arm;g;
-# 	s;.*powerpc.*;power;g;
-# 	s;.*PowerMacintosh.*;power;g;
-# 	s;.*Power.Macintosh.*;power;g;
-# 	s;.*macppc.*;power;g;
-# 	s;.*mips.*;mips;g;
-# 	s;.*ppc64.*;power;g;
-# 	s;.*ppc.*;power;g;
-# 	s;.*alpha.*;alpha;g;
-# 	s;.*sun4u.*;sun4u;g;
-# 	s;.*aarch64.*;arm64;
-# 	s;.*arm64.*;arm64;
-# '`
+if [ -z "$OBJTYPE" ]; then
+OBJTYPE=`(uname -m -p 2>/dev/null || uname -m) | sed '
+       s;.*i[3-6]86.*;386;;
+       s;.*i86pc.*;386;;
+       s;.*amd64.*;x86_64;;
+       s;.*x86_64.*;x86_64;;
+       s;.*armv.*;arm;g;
+       s;.*powerpc.*;power;g;
+       s;.*PowerMacintosh.*;power;g;
+       s;.*Power.Macintosh.*;power;g;
+       s;.*macppc.*;power;g;
+       s;.*mips.*;mips;g;
+       s;.*ppc64.*;power;g;
+       s;.*ppc.*;power;g;
+       s;.*alpha.*;alpha;g;
+       s;.*sun4u.*;sun4u;g;
+       s;.*aarch64.*;arm64;
+       s;.*arm64.*;arm64;
+ '`
+fi
 INSTALL=`[ $(uname) = AIX ] && echo installbsd || echo install`


### PR DESCRIPTION
## Summary
- allow overriding the detected architecture via `./INSTALL -a <arch>`
- pass the selected arch to build scripts through `OBJTYPE`
- skip Solaris/Darwin architecture detection when overridden
- document the new flag in `install.txt` and `README.md`
- make `src/mkenv` fall back to uname when `OBJTYPE` isn't set

## Testing
- `true`