### PR TITLE
Add ia16 OBJTYPE support

### DIFF
--- a/bin/9c
+++ b/bin/9c
@@ -30,6 +30,13 @@ usegcc()
 	cflags="$cflags $CC9FLAGS"
 }
 
+useia16()
+{
+    cc=${CC9:-ia16-elf-gcc}
+    cflags="-c -Os"
+    cflags="$cflags $CC9FLAGS"
+}
+
 quiet()
 {
 	# The uniq at the end is for gcc's strcmp/etc. built-in nonsense,
@@ -108,6 +115,9 @@ usexlc()
 
 tag="${SYSNAME:-`uname`}-${CC9:-cc}"
 case "$tag" in
+*-ia16-elf-gcc*)
+       useia16
+       ;;
 *DragonFly*gcc*|*BSD*gcc*)	usegcc ;;
 *DragonFly*clang|*BSD*clang*)	useclang ;;
 *Darwin*)

--- a/bin/9l
+++ b/bin/9l
@@ -12,6 +12,9 @@ verbose=false
 nmflags=""
 extralibs="-lm"
 tag="${SYSNAME:-`uname`}"
+if echo "${CC9:-gcc}" | grep -q ia16-elf-gcc; then
+       ld="${CC9:-ia16-elf-gcc} $CC9FLAGS"
+else
 case "$tag" in
 *DragonFly*|*BSD*)
 	ld="${CC9:-gcc} $CC9FLAGS"
@@ -67,6 +70,7 @@ case "$tag" in
 	echo do not know how to link on "$tag" 1>&2
 	exit 1
 esac
+fi
 
 if [ "x$1" = "x-l" ]
 then

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,9 @@
 project('plan9port', 'c', default_options: ['c_std=c23'])
 cc = meson.get_compiler('c')
-if cc.get_id() != 'clang'
+objtype = meson.get_external_property('OBJTYPE', '')
+if objtype == 'ia16'
+  message('Configuring for ia16 target')
+elif cc.get_id() != 'clang'
   warning('This project expects clang for best compatibility')
 endif
 add_project_arguments('-Iinclude', language: 'c')

--- a/src/mkenv
+++ b/src/mkenv
@@ -18,6 +18,7 @@ SYSNAME=`uname`
 # 	s;.*alpha.*;alpha;g;
 # 	s;.*sun4u.*;sun4u;g;
 # 	s;.*aarch64.*;arm64;
-# 	s;.*arm64.*;arm64;
+#       s;.*arm64.*;arm64;
+#       s;.*ia16.*;ia16;
 # '`
 INSTALL=`[ $(uname) = AIX ] && echo installbsd || echo install`


### PR DESCRIPTION
## Summary
- support `ia16` OBJTYPE in `src/mkenv`
- add `ia16-elf-gcc` rules to `bin/9c` and `bin/9l`
- allow Meson build to detect `OBJTYPE=ia16`

## Testing
- `meson setup build` *(fails: `meson: command not found`)*