### PR TITLE
Update docs for architecture tiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ Installation
 ------------
 
 To install using the traditional Plan 9 build system, run `./INSTALL`.
-This builds `mk` and then uses it to compile everything else.
+This builds `mk` and then uses it to compile everything else. 64‑bit
+builds are the default and correspond to the project's tier 1 support.
+32‑bit binaries (tier 2) can be produced with `./INSTALL -a 386`. For
+experimental 16‑bit support (tier 3) use `./INSTALL -a ia16`.
 
 Alternatively, a minimal Meson build is provided for modern toolchains
 using `clang` and the C23 standard. Configure it with:

--- a/install.txt
+++ b/install.txt
@@ -64,6 +64,10 @@
           ages are libfontconfig1-dev, libx11-dev, libxext-dev, and
           libxt-dev.  On Ubuntu, it suffices to install xorg-dev.
 
+          Building the ia16 tier requires the external ia16-elf-gcc
+          cross compiler.  Ensure this toolchain is installed and
+          visible in $PATH before running `INSTALL -a ia16`.
+
           INSTALL can safely be repeated to rebuild the system from
           scratch.
 


### PR DESCRIPTION
## Summary
- document build tiers in README
- note ia16 cross-compiler requirement in install.txt

## Testing
- `git status --short`