### PR TITLE
Add Codex setup script and extend CI

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Minimal dependency installation for CI and local dev
+sudo apt-get update
+sudo apt-get install -y build-essential clang clang-tidy llvm lld \
+    qemu-system-x86 qemu-utils ninja-build meson python3 python3-pip
+
+# Ensure meson is available via pip if apt version fails
+if ! command -v meson >/dev/null; then
+    pip3 install --user meson
+fi

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -12,10 +12,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install build deps
         run: |
-          sudo apt update
-          sudo apt install build-essential xorg-dev
+          ./.codex/setup.sh
       - name: Build p9p
         run: ./INSTALL
+      - name: Smoke test with QEMU
+        run: qemu-system-x86_64 -nographic -version
   Build-on-macOS:
     runs-on: [macos-latest]
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install build deps
         run: |
-          sudo apt update
-          sudo apt install build-essential xorg-dev
+          ./.codex/setup.sh
       - name: Build p9p
         run: ./INSTALL
+      - name: Smoke test with QEMU
+        run: qemu-system-x86_64 -nographic -version
   Build-on-macOS:
     runs-on: [macos-latest]
     steps:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -22,6 +22,7 @@ jobs:
           - { id: "black", cmd: "black --check --diff ." }
           - { id: "golangci", cmd: "golangci-lint run --out-format=checkstyle" }
           - { id: "ruff", cmd: "ruff --output-format=github ." }
+          - { id: "clang-tidy", cmd: "clang-tidy $(git ls-files '*.c' '*.h') || true" }
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -29,7 +30,7 @@ jobs:
       - name: Install linter runtime deps
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y shellcheck
+          sudo apt-get install -y shellcheck clang clang-tidy
       - name: Run ${{ matrix.linter.id }} & feed Reviewdog
         uses: reviewdog/reviewdog@master
         with:


### PR DESCRIPTION
## Summary
- add `.codex/setup.sh` for installing clang, clang-tidy, and QEMU
- use the new setup script in CI workflows
- run a QEMU version smoke test
- lint C sources with clang-tidy in Reviewdog

## Testing
- `timeout 10s ./INSTALL -b`
