### PR TITLE
Fix install cleanup and mkenv syntax

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Clean up any lingering mk processes on exit
+trap "pkill -TERM mk 2>/dev/null" EXIT
+
 dobuild=true
 doinstall=true
 OBJTYPE=

--- a/src/mkenv
+++ b/src/mkenv
@@ -2,24 +2,22 @@
 # and also valid shell input for ../dist/buildmk
 
 SYSNAME=`uname`
-if [ -z "$OBJTYPE" ]; then
 OBJTYPE=`(uname -m -p 2>/dev/null || uname -m) | sed '
-       s;.*i[3-6]86.*;386;;
-       s;.*i86pc.*;386;;
-       s;.*amd64.*;x86_64;;
-       s;.*x86_64.*;x86_64;;
-       s;.*armv.*;arm;g;
-       s;.*powerpc.*;power;g;
-       s;.*PowerMacintosh.*;power;g;
-       s;.*Power.Macintosh.*;power;g;
-       s;.*macppc.*;power;g;
-       s;.*mips.*;mips;g;
-       s;.*ppc64.*;power;g;
-       s;.*ppc.*;power;g;
-       s;.*alpha.*;alpha;g;
-       s;.*sun4u.*;sun4u;g;
-       s;.*aarch64.*;arm64;
-       s;.*arm64.*;arm64;
- '`
-fi
+        s;.*i[3-6]86.*;386;;
+        s;.*i86pc.*;386;;
+        s;.*amd64.*;x86_64;;
+        s;.*x86_64.*;x86_64;;
+        s;.*armv.*;arm;g;
+        s;.*powerpc.*;power;g;
+        s;.*PowerMacintosh.*;power;g;
+        s;.*Power.Macintosh.*;power;g;
+        s;.*macppc.*;power;g;
+        s;.*mips.*;mips;g;
+        s;.*ppc64.*;power;g;
+        s;.*ppc.*;power;g;
+        s;.*alpha.*;alpha;g;
+        s;.*sun4u.*;sun4u;g;
+        s;.*aarch64.*;arm64;
+        s;.*arm64.*;arm64;
+'`
 INSTALL=`[ $(uname) = AIX ] && echo installbsd || echo install`


### PR DESCRIPTION
## Summary
- stop mk zombie processes by killing `mk` on exit in INSTALL
- revert `src/mkenv` to syntax understood by `mk`

## Testing
- `./INSTALL -b >install.log 2>&1 && echo DONE`