### PR TITLE
Add stdint usage and modernize uid.c

### DIFF
--- a/src/cmd/9660/boot.c
+++ b/src/cmd/9660/boot.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 
 #include "iso9660.h"
 

--- a/src/cmd/9660/cdrdwr.c
+++ b/src/cmd/9660/cdrdwr.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 
 #include "iso9660.h"
 

--- a/src/cmd/9660/conform.c
+++ b/src/cmd/9660/conform.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 #include <ctype.h>
 #include "iso9660.h"
 

--- a/src/cmd/9660/direc.c
+++ b/src/cmd/9660/direc.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 
 #include "iso9660.h"
 

--- a/src/cmd/9660/dump.c
+++ b/src/cmd/9660/dump.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 #include <ctype.h>
 #include "iso9660.h"
 

--- a/src/cmd/9660/dump9660.c
+++ b/src/cmd/9660/dump9660.c
@@ -3,6 +3,7 @@
 #include <bio.h>
 #include <disk.h>
 #include <libsec.h>
+#include <stdint.h>
 #include "iso9660.h"
 
 ulong now;

--- a/src/cmd/9660/ichar.c
+++ b/src/cmd/9660/ichar.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 #include <ctype.h>
 
 #include "iso9660.h"

--- a/src/cmd/9660/iso9660.h
+++ b/src/cmd/9660/iso9660.h
@@ -9,6 +9,7 @@
  * Also supports El Torito bootable CD spec.
  */
 
+#include <stdint.h>
 typedef struct Cdimg Cdimg;
 typedef struct Cdinfo Cdinfo;
 typedef struct Conform Conform;

--- a/src/cmd/9660/jchar.c
+++ b/src/cmd/9660/jchar.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 
 #include "iso9660.h"
 

--- a/src/cmd/9660/path.c
+++ b/src/cmd/9660/path.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 
 #include "iso9660.h"
 

--- a/src/cmd/9660/plan9.c
+++ b/src/cmd/9660/plan9.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 #include <disk.h>
 #include "iso9660.h"
 

--- a/src/cmd/9660/rune.c
+++ b/src/cmd/9660/rune.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 
 #include "iso9660.h"
 

--- a/src/cmd/9660/sysuse.c
+++ b/src/cmd/9660/sysuse.c
@@ -10,6 +10,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 #include "iso9660.h"
 
 static long mode(Direc*, int);

--- a/src/cmd/9660/uid.c
+++ b/src/cmd/9660/uid.c
@@ -1,5 +1,6 @@
 #include <u.h>
 #include <libc.h>
+#include <stdint.h>
 
 /*
  * /adm/users is
@@ -11,21 +12,14 @@
 
 static int isnumber(char *s);
 
-sniff(Biobuf *b)
+/*
+ * Placeholder sniff implementation to satisfy the compiler.
+ * Real parsing is not provided in this environment.
+ */
+static int sniff(Biobuf *b)
 {
-	read first line of file into p;
-
-	nf = getfields(p, f, nelem(f), ":");
-	if(nf < 4)
-		return nil;
-
-	if(isnumber(f[0]) && !isnumber(f[2]))
-		return _plan9;
-
-	if(!isnumber(f[0]) && isnumber(f[2]))
-		return _unix;
-
-	return nil;
+       USED(b);
+       return 0;
 }
 
 

--- a/src/cmd/9660/unix.c
+++ b/src/cmd/9660/unix.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 #include <disk.h>
 #include <ctype.h>
 

--- a/src/cmd/9660/util.c
+++ b/src/cmd/9660/util.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 #include <ctype.h>
 
 #include "iso9660.h"

--- a/src/cmd/9660/write.c
+++ b/src/cmd/9660/write.c
@@ -2,6 +2,7 @@
 #include <libc.h>
 #include <bio.h>
 #include <libsec.h>
+#include <stdint.h>
 
 #include "iso9660.h"
 


### PR DESCRIPTION
## Summary
- add `<stdint.h>` includes to iso9660 and sources
- stub out unused `sniff` function and give it a return type
- add `<stdint.h>` to all C files for C17 compliance

## Testing
- `mk` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a097ba15883319389b91397fbb5d9